### PR TITLE
adjust frozen path order only if necessary

### DIFF
--- a/adafruit_crickit.py
+++ b/adafruit_crickit.py
@@ -49,7 +49,14 @@ import busio
 from micropython import const
 
 #pylint: disable=wrong-import-position
-sys.path.insert(0, ".frozen")   # Prefer frozen modules over local.
+try:
+    lib_index = sys.path.index("/lib")        # pylint: disable=invalid-name
+    if lib_index < sys.path.index(".frozen"):
+        # Prefer frozen modules over those in /lib.
+        sys.path.insert(lib_index, ".frozen")
+except ValueError:
+    # Don't change sys.path if it doesn't contain "lib" or ".frozen".
+    pass
 
 from adafruit_seesaw.seesaw import Seesaw
 from adafruit_seesaw.pwmout import PWMOut


### PR DESCRIPTION
Put `.frozen` before `lib/` in `sys.path` only if necessary, and only if both are in `sys.path`. This allows testing of non-frozen libraries in `/`, and does not adjust the path if `.frozen` is already before `/lib`.