### PR TITLE
Switch to using I2C singleton

### DIFF
--- a/adafruit_crickit.py
+++ b/adafruit_crickit.py
@@ -44,7 +44,6 @@ Implementation Notes
 import sys
 
 import board
-import busio
 
 from micropython import const
 

--- a/adafruit_crickit.py
+++ b/adafruit_crickit.py
@@ -378,5 +378,5 @@ crickit = None # pylint: disable=invalid-name
 """A singleton instance to control a single Crickit board, controlled by the default I2C pins."""
 
 # Sphinx's board is missing real pins so skip the constructor in that case.
-if "SCL" in dir(board):
-    crickit = Crickit(Seesaw(busio.I2C(board.SCL, board.SDA))) # pylint: disable=invalid-name
+if "I2C" in dir(board):
+    crickit = Crickit(Seesaw(board.I2C())) # pylint: disable=invalid-name


### PR DESCRIPTION
Fixes #19 

```python
Adafruit CircuitPython 4.0.2 on 2019-06-27; Adafruit Feather M4 Express with samd51j19
>>> from adafruit_crickit import crickit
>>> crickit.touch_1.value
False
>>> crickit.touch_1.value
True
>>> import board, busio
>>> i2c = busio.I2C(board.SCL, board.SDA)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: SCL in use
>>> i2c = board.I2C()
>>> i2c.try_lock()
True
>>> i2c.scan()
[19, 73]
>>> i2c.unlock()
>>> crickit.touch_1.value
False
>>>
```