### PR TITLE
Add support for Crickit's on-board NeoPixel

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ In most cases you just need a couple of imports.
   # Strip or ring of 8 NeoPixels
   crickit.init_neopixel(8)
   crickit.neopixel.fill((100, 100, 100))
-  
+
   # Set the Crickit's on-board NeoPixel to a dim purple.
   crickit.init_onboard_pixel(brightness=0.01)
   crickit.onboard_pixel[0] = ((255, 24, 255))

--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,10 @@ In most cases you just need a couple of imports.
   # Strip or ring of 8 NeoPixels
   crickit.init_neopixel(8)
   crickit.neopixel.fill((100, 100, 100))
-
+  
+  # Set the Crickit's on-board NeoPixel to a dim purple.
+  crickit.init_onboard_pixel(brightness=0.01)
+  crickit.onboard_pixel[0] = ((255, 24, 255))
 
 Contributing
 ============

--- a/adafruit_crickit.py
+++ b/adafruit_crickit.py
@@ -393,8 +393,8 @@ class Crickit:
         """
         from adafruit_seesaw.neopixel import NeoPixel
         self._onboard_pixel = NeoPixel(self._seesaw, _SS_PIXEL, n, bpp=bpp,
-                                  brightness=brightness, auto_write=auto_write,
-                                  pixel_order=pixel_order)
+                                       brightness=brightness, auto_write=auto_write,
+                                       pixel_order=pixel_order)
 
     def reset(self):
         """Reset the whole Crickit board."""

--- a/adafruit_crickit.py
+++ b/adafruit_crickit.py
@@ -93,6 +93,7 @@ _TOUCH3 = const(6)
 _TOUCH4 = const(7)
 
 _NEOPIXEL = const(20)
+_SS_PIXEL = const(27)
 
 #pylint: disable=too-few-public-methods
 class CrickitTouchIn:
@@ -164,6 +165,7 @@ class Crickit:
         # Used to find existing devices.
         self._devices = dict()
         self._neopixel = None
+        self._onboard_pixel = None
 
     @property
     def seesaw(self):
@@ -366,6 +368,31 @@ class Crickit:
         """
         from adafruit_seesaw.neopixel import NeoPixel
         self._neopixel = NeoPixel(self._seesaw, _NEOPIXEL, n, bpp=bpp,
+                                  brightness=brightness, auto_write=auto_write,
+                                  pixel_order=pixel_order)
+
+    @property
+    def onboard_pixel(self):
+        """```adafruit_seesaw.neopixel`` object on Seesaw NeoPixel terminal.
+        Raises ValueError if ``init_onboard_pixel`` has not been called.
+        """
+        if not self._onboard_pixel:
+            raise ValueError("Call init_neopixel first")
+        return self._onboard_pixel
+
+
+    def init_onboard_pixel(self, *, n=1, bpp=3, brightness=1.0, auto_write=True, pixel_order=None):
+        """Set up a seesaw.NeoPixel object for the on-board NeoPixel
+
+        .. code-block:: python
+
+          from adafruit_crickit.crickit import crickit
+
+          crickit.init_onboard_pixel()
+          crickit.onboard_pixel.fill((100, 0, 0))
+        """
+        from adafruit_seesaw.neopixel import NeoPixel
+        self._onboard_pixel = NeoPixel(self._seesaw, _SS_PIXEL, n, bpp=bpp,
                                   brightness=brightness, auto_write=auto_write,
                                   pixel_order=pixel_order)
 

--- a/adafruit_crickit.py
+++ b/adafruit_crickit.py
@@ -377,7 +377,7 @@ class Crickit:
         Raises ValueError if ``init_onboard_pixel`` has not been called.
         """
         if not self._onboard_pixel:
-            raise ValueError("Call init_neopixel first")
+            raise ValueError("Call init_onboard_pixel first")
         return self._onboard_pixel
 
 

--- a/adafruit_crickit.py
+++ b/adafruit_crickit.py
@@ -373,7 +373,7 @@ class Crickit:
 
     @property
     def onboard_pixel(self):
-        """```adafruit_seesaw.neopixel`` object on Seesaw NeoPixel terminal.
+        """```adafruit_seesaw.neopixel`` object on the Seesaw on-board NeoPixel.
         Raises ValueError if ``init_onboard_pixel`` has not been called.
         """
         if not self._onboard_pixel:


### PR DESCRIPTION
The init_onboard_pixel() argument structure is similar to init_neopixel():
```
def init_neopixel(self, n, *, bpp=3, brightness=1.0, auto_write=True, pixel_order=None):

def init_onboard_pixel(self, *, n=1, bpp=3, brightness=1.0, auto_write=True, pixel_order=None):
```
Example:
```
from adafruit_crickit import crickit
crickit.init_onboard_pixel(brightness=0.01)
crickit.onboard_pixel[0] = ((255, 24, 255))
```