### PR TITLE
Add support for Crickit's on-board NeoPixel

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Usage Example
 This examples shows how to control all the devices supported by the library.
 In most cases you just need a couple of imports.
 
-.. code-block :: python
+.. code-block:: python
 
   # This is a mock example showing typical usage of the library for each kind of device.
 
@@ -103,6 +103,9 @@ In most cases you just need a couple of imports.
   crickit.init_neopixel(8)
   crickit.neopixel.fill((100, 100, 100))
 
+  # Set the Crickit's on-board NeoPixel to a dim purple.
+  crickit.init_onboard_pixel(brightness=0.01)
+  crickit.onboard_pixel[0] = ((255, 24, 255))
 
 Contributing
 ============

--- a/adafruit_crickit.py
+++ b/adafruit_crickit.py
@@ -374,7 +374,7 @@ class Crickit:
     @property
     def onboard_pixel(self):
         """```adafruit_seesaw.neopixel`` object on the Seesaw on-board NeoPixel.
-        Initialize on-board NeoPixel upon first use.
+        Initialize on-board NeoPixel and clear upon first use.
         """
         if not self._onboard_pixel:
             from adafruit_seesaw.neopixel import NeoPixel
@@ -382,7 +382,7 @@ class Crickit:
             self._onboard_pixel = NeoPixel(self._seesaw, _SS_PIXEL, 1, bpp=3,
                                            brightness=self.brightness, auto_write=True,
                                            pixel_order=None)
-            self._onboard_pixel.fill((0, 0, 0))  # clear on-board NeoPixel
+            self._onboard_pixel.fill((0, 0, 0))
         return self._onboard_pixel
 
     def reset(self):

--- a/adafruit_crickit.py
+++ b/adafruit_crickit.py
@@ -374,27 +374,16 @@ class Crickit:
     @property
     def onboard_pixel(self):
         """```adafruit_seesaw.neopixel`` object on the Seesaw on-board NeoPixel.
-        Raises ValueError if ``init_onboard_pixel`` has not been called.
+        Initialize on-board NeoPixel upon first use.
         """
         if not self._onboard_pixel:
-            raise ValueError("Call init_onboard_pixel first")
+            from adafruit_seesaw.neopixel import NeoPixel
+            self.brightness = 1.0
+            self._onboard_pixel = NeoPixel(self._seesaw, _SS_PIXEL, 1, bpp=3,
+                                           brightness=self.brightness, auto_write=True,
+                                           pixel_order=None)
+            self._onboard_pixel.fill((0, 0, 0))  # clear on-board NeoPixel
         return self._onboard_pixel
-
-
-    def init_onboard_pixel(self, *, n=1, bpp=3, brightness=1.0, auto_write=True, pixel_order=None):
-        """Set up a seesaw.NeoPixel object for the on-board NeoPixel
-
-        .. code-block:: python
-
-          from adafruit_crickit.crickit import crickit
-
-          crickit.init_onboard_pixel()
-          crickit.onboard_pixel.fill((100, 0, 0))
-        """
-        from adafruit_seesaw.neopixel import NeoPixel
-        self._onboard_pixel = NeoPixel(self._seesaw, _SS_PIXEL, n, bpp=bpp,
-                                       brightness=brightness, auto_write=auto_write,
-                                       pixel_order=pixel_order)
 
     def reset(self):
         """Reset the whole Crickit board."""

--- a/adafruit_crickit.py
+++ b/adafruit_crickit.py
@@ -165,7 +165,9 @@ class Crickit:
         # Used to find existing devices.
         self._devices = dict()
         self._neopixel = None
+        # Set initial on-board NeoPixel status and brightness
         self._onboard_pixel = None
+        self.brightness = 1.0
 
     @property
     def seesaw(self):
@@ -378,7 +380,6 @@ class Crickit:
         """
         if not self._onboard_pixel:
             from adafruit_seesaw.neopixel import NeoPixel
-            self.brightness = 1.0
             self._onboard_pixel = NeoPixel(self._seesaw, _SS_PIXEL, 1, bpp=3,
                                            brightness=self.brightness, auto_write=True,
                                            pixel_order=None)

--- a/adafruit_crickit.py
+++ b/adafruit_crickit.py
@@ -165,9 +165,7 @@ class Crickit:
         # Used to find existing devices.
         self._devices = dict()
         self._neopixel = None
-        # Set initial on-board NeoPixel status and brightness
         self._onboard_pixel = None
-        self.brightness = 1.0
 
     @property
     def seesaw(self):
@@ -381,7 +379,7 @@ class Crickit:
         if not self._onboard_pixel:
             from adafruit_seesaw.neopixel import NeoPixel
             self._onboard_pixel = NeoPixel(self._seesaw, _SS_PIXEL, 1, bpp=3,
-                                           brightness=self.brightness, auto_write=True,
+                                           brightness=1.0, auto_write=True,
                                            pixel_order=None)
             self._onboard_pixel.fill((0, 0, 0))
         return self._onboard_pixel

--- a/adafruit_crickit.py
+++ b/adafruit_crickit.py
@@ -93,6 +93,7 @@ _TOUCH3 = const(6)
 _TOUCH4 = const(7)
 
 _NEOPIXEL = const(20)
+_SS_PIXEL = const(27)
 
 #pylint: disable=too-few-public-methods
 class CrickitTouchIn:
@@ -164,6 +165,7 @@ class Crickit:
         # Used to find existing devices.
         self._devices = dict()
         self._neopixel = None
+        self._onboard_pixel = None
 
     @property
     def seesaw(self):
@@ -368,6 +370,31 @@ class Crickit:
         self._neopixel = NeoPixel(self._seesaw, _NEOPIXEL, n, bpp=bpp,
                                   brightness=brightness, auto_write=auto_write,
                                   pixel_order=pixel_order)
+
+    @property
+    def onboard_pixel(self):
+        """```adafruit_seesaw.neopixel`` object on the Seesaw on-board NeoPixel.
+        Raises ValueError if ``init_onboard_pixel`` has not been called.
+        """
+        if not self._onboard_pixel:
+            raise ValueError("Call init_onboard_pixel first")
+        return self._onboard_pixel
+
+
+    def init_onboard_pixel(self, *, n=1, bpp=3, brightness=1.0, auto_write=True, pixel_order=None):
+        """Set up a seesaw.NeoPixel object for the on-board NeoPixel
+
+        .. code-block:: python
+
+          from adafruit_crickit.crickit import crickit
+
+          crickit.init_onboard_pixel()
+          crickit.onboard_pixel.fill((100, 0, 0))
+        """
+        from adafruit_seesaw.neopixel import NeoPixel
+        self._onboard_pixel = NeoPixel(self._seesaw, _SS_PIXEL, n, bpp=bpp,
+                                       brightness=brightness, auto_write=auto_write,
+                                       pixel_order=pixel_order)
 
     def reset(self):
         """Reset the whole Crickit board."""


### PR DESCRIPTION
Incorporated suggestion to initialize upon first use of `crickit.onboard_pixel`. Pixel brightness can also be set at any time `crickit.onboard_pixel.brightness`. 

Example:
```
from adafruit_crickit import crickit
crickit.onboard_pixel.brightness = 0.01

# set Crickit on-board NeoPixel to purple
crickit.onboard_pixel[0] = (255, 24, 255)
# or
crickit.onboard_pixel.fill((255, 24, 255))
```
