### PR TITLE
Add missing pixelbuf dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@
 Adafruit-Blinka
 adafruit-circuitpython-seesaw
 adafruit-circuitpython-motor
+adafruit-circuitpython-pixelbuf


### PR DESCRIPTION
Fixes #35 which is a result of a slightly botched transition to `pyproject.toml`.